### PR TITLE
[#174004231] Amount could be a single digit

### DIFF
--- a/src/__tests__/pagopa.test.ts
+++ b/src/__tests__/pagopa.test.ts
@@ -207,7 +207,7 @@ describe("QrCodeFromString", () => {
       "should succeed with valid QrCode for auxDigit equals 2"
     ]
   ])(
-    "%s, %s, %s, %s, %s",
+    "%s, %s, %s, %s, %d",
     (
       qrCodeSrt,
       paymentNoticeNumber,

--- a/src/__tests__/pagopa.test.ts
+++ b/src/__tests__/pagopa.test.ts
@@ -219,11 +219,7 @@ describe("QrCodeFromString", () => {
       expect(isRight(validation)).toBeTruthy();
       if (isRight(validation)) {
         expect(validation.value.amount).toHaveLength(expectedAmountLength);
-        const maybeAmount = AmountInEuroCents.decode(validation.value.amount);
-        expect(maybeAmount.isRight()).toBeTruthy();
-        if (maybeAmount.isRight()) {
-          expect(parseInt(maybeAmount.value, 10)).toEqual(amountInCents);
-        }
+        expect(parseInt(validation.value.amount, 10)).toEqual(amountInCents);
         expect(validation.value.identifier).toHaveLength(6);
         expect(validation.value.version).toHaveLength(3);
         expect(validation.value.organizationFiscalCode).toHaveLength(11);

--- a/src/pagopa.ts
+++ b/src/pagopa.ts
@@ -9,7 +9,9 @@ import {
   PatternString
 } from "italia-ts-commons/lib/strings";
 
-export const MIN_AMOUNT_DIGITS = 2;
+// MIN_AMOUNT_DIGITS should be 2. This constraint changes since several qrcode are been encoded using only 1 digit
+// see https://www.pivotaltracker.com/story/show/174004231
+export const MIN_AMOUNT_DIGITS = 1;
 export const MAX_AMOUNT_DIGITS = 10;
 export const CENTS_IN_ONE_EURO = 100;
 export const AmountInEuroCents = PatternString(
@@ -41,7 +43,7 @@ export const AmountInEuroCentsFromNumber = new t.Type<
 
 const PAYMENT_NOTICE_NUMBER_LENGTH = 18;
 
-const MIN_QR_CODE_LENGTH = 44;
+const MIN_QR_CODE_LENGTH = 43;
 const MAX_QR_CODE_LENGTH = 52;
 
 const ORGANIZATION_FISCAL_CODE_LENGTH = 11;
@@ -311,8 +313,8 @@ export const PaymentNoticeQrCodeFromString = new t.Type<
 >(
   "PaymentNoticeQrCodeFromString",
   PaymentNoticeQrCode.is,
-  (v, c) =>
-    PaymentNoticeQrCode.is(v)
+  (v, c) => {
+    return PaymentNoticeQrCode.is(v)
       ? t.success(v)
       : t.string.validate(v, c).chain(s => {
           if (s.length < MIN_QR_CODE_LENGTH || s.length > MAX_QR_CODE_LENGTH) {
@@ -334,7 +336,8 @@ export const PaymentNoticeQrCodeFromString = new t.Type<
             paymentNoticeNumber,
             version
           });
-        }),
+        });
+  },
   paymentNoticeQrCodeToString
 );
 

--- a/src/pagopa.ts
+++ b/src/pagopa.ts
@@ -313,8 +313,8 @@ export const PaymentNoticeQrCodeFromString = new t.Type<
 >(
   "PaymentNoticeQrCodeFromString",
   PaymentNoticeQrCode.is,
-  (v, c) => {
-    return PaymentNoticeQrCode.is(v)
+  (v, c) =>
+    PaymentNoticeQrCode.is(v)
       ? t.success(v)
       : t.string.validate(v, c).chain(s => {
           if (s.length < MIN_QR_CODE_LENGTH || s.length > MAX_QR_CODE_LENGTH) {
@@ -336,8 +336,7 @@ export const PaymentNoticeQrCodeFromString = new t.Type<
             paymentNoticeNumber,
             version
           });
-        });
-  },
+        }),
   paymentNoticeQrCodeToString
 );
 

--- a/src/pagopa.ts
+++ b/src/pagopa.ts
@@ -9,7 +9,7 @@ import {
   PatternString
 } from "italia-ts-commons/lib/strings";
 
-// MIN_AMOUNT_DIGITS should be 2. This constraint changes since several qrcode are been encoded using only 1 digit
+// MIN_AMOUNT_DIGITS is 2 by specs. We amend this since several QRCodes have been encoded using only 1 digit
 // see https://www.pivotaltracker.com/story/show/174004231
 export const MIN_AMOUNT_DIGITS = 1;
 export const MAX_AMOUNT_DIGITS = 10;


### PR DESCRIPTION
This PR allows to parse amounts consisting of a single digit.

before ❌
`PAGOPA|002|322201151398574181|81005750021|1` 

now  :white_check_mark:
`PAGOPA|002|322201151398574181|81005750021|1`