### PR TITLE
[IABT-1260] Support amount with 12 digits

### DIFF
--- a/src/__tests__/pagopa.test.ts
+++ b/src/__tests__/pagopa.test.ts
@@ -199,6 +199,14 @@ describe("QrCodeFromString", () => {
       "should succeed with valid QrCode of four digits amount"
     ],
     [
+      "PAGOPA|002|001721265093769322|00087640256|10100000002",
+      "7212650937693",
+      11,
+      "0",
+      10100000002,
+      "should succeed with valid QrCode of twelve (max) digits amount"
+    ],
+    [
       "PAGOPA|002|223456789012345678|12345678901|1234567801",
       "234567890123456",
       10,
@@ -218,6 +226,7 @@ describe("QrCodeFromString", () => {
       const validation = PaymentNoticeQrCodeFromString.decode(qrCodeSrt);
       expect(isRight(validation)).toBeTruthy();
       if (isRight(validation)) {
+        console.log(JSON.stringify(validation.value));
         expect(validation.value.amount).toHaveLength(expectedAmountLength);
         expect(parseInt(validation.value.amount, 10)).toEqual(amountInCents);
         expect(validation.value.identifier).toHaveLength(6);

--- a/src/pagopa.ts
+++ b/src/pagopa.ts
@@ -12,7 +12,7 @@ import {
 // MIN_AMOUNT_DIGITS is 2 by specs. We amend this since several QRCodes have been encoded using only 1 digit
 // see https://www.pivotaltracker.com/story/show/174004231
 export const MIN_AMOUNT_DIGITS = 1;
-export const MAX_AMOUNT_DIGITS = 10;
+export const MAX_AMOUNT_DIGITS = 12;
 export const CENTS_IN_ONE_EURO = 100;
 export const AmountInEuroCents = PatternString(
   `^[0-9]{${MIN_AMOUNT_DIGITS},${MAX_AMOUNT_DIGITS}}$`
@@ -44,7 +44,7 @@ export const AmountInEuroCentsFromNumber = new t.Type<
 const PAYMENT_NOTICE_NUMBER_LENGTH = 18;
 
 const MIN_QR_CODE_LENGTH = 43;
-const MAX_QR_CODE_LENGTH = 52;
+const MAX_QR_CODE_LENGTH = 54;
 
 const ORGANIZATION_FISCAL_CODE_LENGTH = 11;
 


### PR DESCRIPTION
This PR extends the amount digits from 10 to 12

### max amount supported
**before**
9.999.999,999

**now**
999.999.999,999